### PR TITLE
[Feat] 사용자 알림정보 저장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.zip
 *.tar.gz
 *.rar
+*.idea
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/app/src/main/java/org/sopt/app/application/alert/AlertService.java
+++ b/app/src/main/java/org/sopt/app/application/alert/AlertService.java
@@ -1,8 +1,14 @@
 package org.sopt.app.application.alert;
 
 import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.app.application.alert.command.SaveAlertCommand;
+import org.sopt.app.common.exception.UserNotFoundException;
+import org.sopt.app.domain.entity.Alert;
 import org.sopt.app.domain.enums.Parts;
-import org.sopt.app.presentation.alert.dto.PartRspDTO;
+import org.sopt.app.interfaces.postgres.UserJpaRepository;
+import org.sopt.app.interfaces.postgres.alert.AlertRepository;
+import org.sopt.app.presentation.alert.dto.PartsDTO;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -10,18 +16,37 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class AlertService {
+public class AlertService implements AlertUseCase {
 
-    public PartRspDTO findPart() {
+    private final UserJpaRepository userJpaRepository;
+    private final AlertRepository alertRepository;
+
+    public PartsDTO findPart() {
 
         //ENUM 값을 통해 part 들을 받아온다.
         List<String> partString = new ArrayList<>();
-        for(Parts part : Parts.values()){
+        for (Parts part : Parts.values()) {
             partString.add(part.toString());
         }
 
-        return PartRspDTO.builder()
+        return PartsDTO.builder()
                 .parts(partString)
                 .build();
+    }
+
+    public void saveParts(SaveAlertCommand command) {
+        val user = userJpaRepository.findById(command.getUserId())
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 유저 아이디입니다."));
+        if (command.getPartsDto().getActive()) {
+            alertRepository.save(Alert.builder()
+                    .tmpUserId(user.getId())
+                    .topic(command.getPartsDto().getParts())
+                    .active(true)
+                    .build());
+        } else {
+            alertRepository.save(Alert.builder()
+                    .tmpUserId(user.getId())
+                    .build());
+        }
     }
 }

--- a/app/src/main/java/org/sopt/app/application/alert/AlertService.java
+++ b/app/src/main/java/org/sopt/app/application/alert/AlertService.java
@@ -8,7 +8,7 @@ import org.sopt.app.domain.entity.Alert;
 import org.sopt.app.domain.enums.Parts;
 import org.sopt.app.interfaces.postgres.UserJpaRepository;
 import org.sopt.app.interfaces.postgres.alert.AlertRepository;
-import org.sopt.app.presentation.alert.dto.PartsDTO;
+import org.sopt.app.presentation.alert.dto.PartResponseDTO;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ public class AlertService implements AlertUseCase {
     private final UserJpaRepository userJpaRepository;
     private final AlertRepository alertRepository;
 
-    public PartsDTO findPart() {
+    public PartResponseDTO findPart() {
 
         //ENUM 값을 통해 part 들을 받아온다.
         List<String> partString = new ArrayList<>();
@@ -29,7 +29,7 @@ public class AlertService implements AlertUseCase {
             partString.add(part.toString());
         }
 
-        return PartsDTO.builder()
+        return PartResponseDTO.builder()
                 .parts(partString)
                 .build();
     }

--- a/app/src/main/java/org/sopt/app/application/alert/AlertUseCase.java
+++ b/app/src/main/java/org/sopt/app/application/alert/AlertUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.app.application.alert;
+
+import org.sopt.app.application.alert.command.SaveAlertCommand;
+
+public interface AlertUseCase {
+
+    void saveParts(SaveAlertCommand command);
+}

--- a/app/src/main/java/org/sopt/app/application/alert/SendAlertUseCase.java
+++ b/app/src/main/java/org/sopt/app/application/alert/SendAlertUseCase.java
@@ -1,4 +1,0 @@
-package org.sopt.app.application.alert;
-
-public interface SendAlertUseCase {
-}

--- a/app/src/main/java/org/sopt/app/application/alert/command/SaveAlertCommand.java
+++ b/app/src/main/java/org/sopt/app/application/alert/command/SaveAlertCommand.java
@@ -1,0 +1,18 @@
+package org.sopt.app.application.alert.command;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.app.presentation.alert.dto.SavePartsDTO;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SaveAlertCommand {
+    private Long userId;
+    private SavePartsDTO partsDto;
+}
+

--- a/app/src/main/java/org/sopt/app/application/notice/NoticeService.java
+++ b/app/src/main/java/org/sopt/app/application/notice/NoticeService.java
@@ -4,7 +4,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.domain.entity.Notice;
 import org.sopt.app.domain.entity.QNotice;
-import org.sopt.app.interfaces.notice.NoticeRepository;
+import org.sopt.app.interfaces.postgres.NoticeRepository;
 import org.sopt.app.presentation.notice.dto.NoticeRequestDTO;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -41,9 +41,9 @@ public class NoticeService {
         List<Notice> list = queryFactory.select(qNotice)
                 .from(qNotice)
                 .where(
-                         StringUtils.hasText(part) ? qNotice.part.eq(part) : null
-                        ,StringUtils.hasText(scope) ? qNotice.scope.eq(scope) : null
-                        ,StringUtils.hasText(title) ? qNotice.title.contains(title) : null
+                        StringUtils.hasText(part) ? qNotice.part.eq(part) : null
+                        , StringUtils.hasText(scope) ? qNotice.scope.eq(scope) : null
+                        , StringUtils.hasText(title) ? qNotice.title.contains(title) : null
                 ).orderBy(qNotice.id.desc())
                 .fetch();
         return list;
@@ -72,18 +72,18 @@ public class NoticeService {
 
         Notice notice = noticeRepository.getReferenceById(noticeRequestDTO.getId());
 
-        if(StringUtils.hasText(noticeRequestDTO.getTitle())) notice.changeTitle(noticeRequestDTO.getTitle());
-        if(StringUtils.hasText(noticeRequestDTO.getContents())) notice.changeContents(noticeRequestDTO.getContents());
-        if(StringUtils.hasText(noticeRequestDTO.getPart())) notice.changePart(noticeRequestDTO.getPart());
-        if(StringUtils.hasText(noticeRequestDTO.getScope())) notice.changeScope(noticeRequestDTO.getScope());
-        if(StringUtils.hasText(noticeRequestDTO.getCreator())) notice.changeCreator(noticeRequestDTO.getCreator());
+        if (StringUtils.hasText(noticeRequestDTO.getTitle())) notice.changeTitle(noticeRequestDTO.getTitle());
+        if (StringUtils.hasText(noticeRequestDTO.getContents())) notice.changeContents(noticeRequestDTO.getContents());
+        if (StringUtils.hasText(noticeRequestDTO.getPart())) notice.changePart(noticeRequestDTO.getPart());
+        if (StringUtils.hasText(noticeRequestDTO.getScope())) notice.changeScope(noticeRequestDTO.getScope());
+        if (StringUtils.hasText(noticeRequestDTO.getCreator())) notice.changeCreator(noticeRequestDTO.getCreator());
 
         return noticeRepository.save(notice);
     }
 
     // 게시글 삭제
     @Transactional
-    public void deleteById(Long id){
+    public void deleteById(Long id) {
         noticeRepository.deleteById(id);
     }
 

--- a/app/src/main/java/org/sopt/app/common/exception/UserNotFoundException.java
+++ b/app/src/main/java/org/sopt/app/common/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package org.sopt.app.common.exception;
+
+public class UserNotFoundException extends RuntimeException{
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/app/src/main/java/org/sopt/app/domain/entity/Alert.java
+++ b/app/src/main/java/org/sopt/app/domain/entity/Alert.java
@@ -1,13 +1,11 @@
 package org.sopt.app.domain.entity;
 
 import com.vladmihalcea.hibernate.type.array.ListArrayType;
+import lombok.Builder;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.util.List;
 
 @Entity
@@ -18,6 +16,7 @@ import java.util.List;
 )
 public class Alert {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column
@@ -28,4 +27,18 @@ public class Alert {
             columnDefinition = "text[]"
     )
     private List<String> topic;
+
+    @Column
+    private Boolean active;
+
+    @Builder
+    public Alert(Long tmpUserId, List<String> topic, Boolean active) {
+        this.tmpUserId = tmpUserId;
+        this.topic = topic;
+        this.active = active;
+    }
+
+    public Alert() {
+
+    }
 }

--- a/app/src/main/java/org/sopt/app/domain/entity/User.java
+++ b/app/src/main/java/org/sopt/app/domain/entity/User.java
@@ -1,22 +1,30 @@
 package org.sopt.app.domain.entity;
 
+import lombok.Getter;
 import org.sopt.app.domain.enums.Authority;
+import org.sopt.app.domain.enums.OsType;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Table(name = "TMP_USER")
+@Getter
 public class User {
 
     @Id
     private Long id;
 
     @Column
+    private String email;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private Authority auth;
+
+    @Column
     private String clientToken;
 
     @Column
-    private Authority auth;
+    @Enumerated(EnumType.STRING)
+    private OsType osType;
 }

--- a/app/src/main/java/org/sopt/app/domain/enums/OsType.java
+++ b/app/src/main/java/org/sopt/app/domain/enums/OsType.java
@@ -1,0 +1,6 @@
+package org.sopt.app.domain.enums;
+
+public enum OsType {
+    ANDRIOID,
+    IOS
+}

--- a/app/src/main/java/org/sopt/app/interfaces/alert/AlertRepository.java
+++ b/app/src/main/java/org/sopt/app/interfaces/alert/AlertRepository.java
@@ -1,7 +1,0 @@
-package org.sopt.app.interfaces.alert;
-
-import org.sopt.app.domain.entity.Alert;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AlertRepository extends JpaRepository<Alert, Integer> {
-}

--- a/app/src/main/java/org/sopt/app/interfaces/postgres/NoticeRepository.java
+++ b/app/src/main/java/org/sopt/app/interfaces/postgres/NoticeRepository.java
@@ -1,4 +1,4 @@
-package org.sopt.app.interfaces.notice;
+package org.sopt.app.interfaces.postgres;
 
 import org.sopt.app.domain.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/app/src/main/java/org/sopt/app/interfaces/postgres/UserJpaRepository.java
+++ b/app/src/main/java/org/sopt/app/interfaces/postgres/UserJpaRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.app.interfaces.postgres;
+
+import org.sopt.app.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+}

--- a/app/src/main/java/org/sopt/app/interfaces/postgres/alert/AlertRepository.java
+++ b/app/src/main/java/org/sopt/app/interfaces/postgres/alert/AlertRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.app.interfaces.postgres.alert;
+
+import org.sopt.app.domain.entity.Alert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlertRepository extends JpaRepository<Alert, Long> {
+}

--- a/app/src/main/java/org/sopt/app/presentation/alert/AlertController.java
+++ b/app/src/main/java/org/sopt/app/presentation/alert/AlertController.java
@@ -3,7 +3,7 @@ package org.sopt.app.presentation.alert;
 import lombok.AllArgsConstructor;
 import org.sopt.app.application.alert.AlertService;
 import org.sopt.app.application.alert.command.SaveAlertCommand;
-import org.sopt.app.presentation.alert.dto.PartsDTO;
+import org.sopt.app.presentation.alert.dto.PartResponseDTO;
 import org.sopt.app.presentation.alert.dto.SavePartsDTO;
 import org.sopt.app.presentation.notice.BaseController;
 import org.springframework.http.HttpStatus;
@@ -21,7 +21,7 @@ public class AlertController extends BaseController {
      */
     @GetMapping(value = "/alert/part")
     @ResponseBody
-    public ResponseEntity<PartsDTO> findPart() {
+    public ResponseEntity<PartResponseDTO> findPart() {
         return new ResponseEntity<>(alertService.findPart(), getSuccessHeaders(), HttpStatus.OK);
     }
 

--- a/app/src/main/java/org/sopt/app/presentation/alert/AlertController.java
+++ b/app/src/main/java/org/sopt/app/presentation/alert/AlertController.java
@@ -2,26 +2,41 @@ package org.sopt.app.presentation.alert;
 
 import lombok.AllArgsConstructor;
 import org.sopt.app.application.alert.AlertService;
-import org.sopt.app.presentation.alert.dto.PartRspDTO;
+import org.sopt.app.application.alert.command.SaveAlertCommand;
+import org.sopt.app.presentation.alert.dto.PartsDTO;
+import org.sopt.app.presentation.alert.dto.SavePartsDTO;
 import org.sopt.app.presentation.notice.BaseController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @AllArgsConstructor
 public class AlertController extends BaseController {
 
     private final AlertService alertService;
+
     /**
      * 파트 목록 조회하기
-     * @return
      */
     @GetMapping(value = "/alert/part")
     @ResponseBody
-    public ResponseEntity<PartRspDTO> findPart() {
+    public ResponseEntity<PartsDTO> findPart() {
         return new ResponseEntity<>(alertService.findPart(), getSuccessHeaders(), HttpStatus.OK);
+    }
+
+    /**
+     * 파트 알림정보 저장
+     */
+
+    @PostMapping(value = "/alert/{user_id}")
+    public void saveParts(
+            @PathVariable(name = "user_id") Long userId,
+            @RequestBody SavePartsDTO partsDto
+    ) {
+        alertService.saveParts(SaveAlertCommand.builder()
+                .userId(userId)
+                .partsDto(partsDto)
+                .build());
     }
 }

--- a/app/src/main/java/org/sopt/app/presentation/alert/dto/PartResponseDTO.java
+++ b/app/src/main/java/org/sopt/app/presentation/alert/dto/PartResponseDTO.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PartRspDTO {
+public class PartResponseDTO {
     private List<String> parts;
 }

--- a/app/src/main/java/org/sopt/app/presentation/alert/dto/SavePartsDTO.java
+++ b/app/src/main/java/org/sopt/app/presentation/alert/dto/SavePartsDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.app.presentation.alert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SavePartsDTO {
+    private List<String> parts;
+    private Boolean active;
+}


### PR DESCRIPTION
## 작업내용

1. 이메일 인증 완료 이후 알림받을 파트 정보 저장하는 로직을 추가
- 파트 선택 후 팝업창에서 알림설정을 하지 않더라도 API 에서 active: false로 데이터 받도록 수정
- 추후 마이페이지에서 알림 설정 용이하게 하기 위함
 
2. gitignore에 .idea 추가
3. User, Alert 테이블 수정

- Long으로 타입 변경
- Alert 테이블에 active 값 추가(os 알림설정 여부)
- User 정보에 email 추가


** 추후에 기존 db의 user table 볼 수 있으면 좋은데, 협의 필요

