### PR TITLE
[Fix] 스탬프 등록시 중복 등록 방지

### DIFF
--- a/src/main/java/org/sopt/app/application/stamp/StampService.java
+++ b/src/main/java/org/sopt/app/application/stamp/StampService.java
@@ -1,5 +1,6 @@
 package org.sopt.app.application.stamp;
 
+import static org.sopt.app.common.ResponseCode.DUPLICATE_STAMP;
 import static org.sopt.app.common.ResponseCode.INVALID_RESPONSE;
 
 import java.time.LocalDateTime;
@@ -106,6 +107,19 @@ public class StampService {
 
     stampRepository.deleteById(stampId);
   }
+
+
+  //스탬프 중복 검사체크
+  @Transactional
+  public void checkDuplicateStamp(String userId, Long missionId){
+    Stamp stamp = stampRepository.findByUserIdAndMissionId(Long.valueOf(userId), missionId);
+
+    if(stamp != null){
+      throw new ApiException(DUPLICATE_STAMP);
+    }
+  }
+
+
 
   //Stamp 삭제 All by UserId
   @Transactional

--- a/src/main/java/org/sopt/app/common/ResponseCode.java
+++ b/src/main/java/org/sopt/app/common/ResponseCode.java
@@ -13,7 +13,8 @@ public enum ResponseCode {
 
     INVALID_RESPONSE("99", "99", "9999", "요청이 처리 되지 않았습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     SUCCESS("00","00", "0000", "정상 처리되었습니다.", HttpStatus.OK),
-    INVALID_REQUEST("00", "01", "0001", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_REQUEST("00", "01", "0001", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_STAMP("00", "02", "0002", "중복된 스탬프 등록 요청입니다.", HttpStatus.BAD_REQUEST);
 
     private final String codeGroup;
     private final String code;

--- a/src/main/java/org/sopt/app/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/org/sopt/app/common/exception/ApiExceptionHandler.java
@@ -1,0 +1,28 @@
+package org.sopt.app.common.exception;
+
+import static org.sopt.app.common.constants.Constants.RESULT_CODE;
+import static org.sopt.app.common.constants.Constants.RESULT_MESSAGE;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+  @ExceptionHandler({ApiException.class})
+  protected void handle(ApiException apiException, HttpServletRequest request,
+      HttpServletResponse response) {
+
+    final String encodingResultMessage = URLEncoder
+        .encode(apiException.getMessage(), StandardCharsets.UTF_8);
+
+    response.setHeader(RESULT_CODE, apiException.getResultCode());
+    response.setHeader(RESULT_MESSAGE, encodingResultMessage);
+    response.setStatus(apiException.getHttpStatus().value());
+  }
+
+}

--- a/src/main/java/org/sopt/app/presentation/stamp/StampController.java
+++ b/src/main/java/org/sopt/app/presentation/stamp/StampController.java
@@ -46,6 +46,9 @@ public class StampController extends BaseController {
       @RequestPart(name = "imgUrl", required = false) List<MultipartFile> multipartFiles
   ) {
 
+    //스탬프 중복 검사체크
+    stampService.checkDuplicateStamp(userId, missionId);
+
     List<String> imgPaths = s3Service.upload(multipartFiles);
     Stamp uploadStamp = stampService.uploadStamp(stampRequestDto,
         imgPaths, userId, missionId);


### PR DESCRIPTION
스탬프 등록시 중복 등록되는 현상을 방지하기 위하여

userId, missioinId로 Stamp 테이블 조회 후 이미 있는 데이터라면 

400 BadRequest 로 ApiException 을 던진다.

